### PR TITLE
Change Twig instantiation responsability

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -22,9 +22,19 @@ try {
         $view->setViewsDir('app/views/');
         $view->registerEngines([
             View\Engine\Twig::DEFAULT_EXTENSION => function ($view, $di) {
-                return new View\Engine\Twig($view, $di, [
-                    'cache' => __DIR__ . '/app/cache/',
-                ]);
+				
+				$loader = new \Twig_Loader_Filesystem($view->getViewsDir());
+				$environment = new \Twig_Environment($loader, [
+					'cache' => __DIR__ . '/app/cache/'
+				]);
+
+				// Add extensions, filter, functions and more here!
+                // $environment->addExtension(...);
+                // $environment->addFilter(...);
+				// $environment->addFunction(...);
+
+				return new \Phalcon\Mvc\View\Engine\Twig($view, $di, $environment);
+
             }
         ]);
 

--- a/example/index.php
+++ b/example/index.php
@@ -22,19 +22,17 @@ try {
         $view->setViewsDir('app/views/');
         $view->registerEngines([
             View\Engine\Twig::DEFAULT_EXTENSION => function ($view, $di) {
-				
-				$loader = new \Twig_Loader_Filesystem($view->getViewsDir());
-				$environment = new \Twig_Environment($loader, [
-					'cache' => __DIR__ . '/app/cache/'
-				]);
+                $twig = new View\Engine\Twig($view, $di, [
+                    'cache' => __DIR__ . '/app/cache/',
+                ]);
 
-				// Add extensions, filter, functions and more here!
-                // $environment->addExtension(...);
-                // $environment->addFilter(...);
-				// $environment->addFunction(...);
+                $environment = $twig->getEnvironment();
 
-				return new \Phalcon\Mvc\View\Engine\Twig($view, $di, $environment);
+                $environment->addExtension(new \Twig_Debug_Extension());
+                // $environment->addFunction(...);
+                // $environemnt->addFilter(...);
 
+                return $twig;
             }
         ]);
 

--- a/src/Mvc/View/Engine/Twig.php
+++ b/src/Mvc/View/Engine/Twig.php
@@ -23,7 +23,7 @@ class Twig extends Engine implements EngineInterface
      * @param mixed|\Phalcon\DiInterface $dependencyInjector
      * @param array $options
      */
-    public function __construct($view, $dependencyInjector, array $environmentoOptions = [])
+    public function __construct($view, $dependencyInjector, array $options = [])
     {
         parent::__construct($view, $dependencyInjector);
 

--- a/src/Mvc/View/Engine/Twig.php
+++ b/src/Mvc/View/Engine/Twig.php
@@ -16,19 +16,24 @@ class Twig extends Engine implements EngineInterface
     /**
      * @var \Twig_Environment
      */
-    protected $twig;
+    protected $_twig;
 
     /**
      * @param mixed|\Phalcon\Mvc\ViewBaseInterface $view
      * @param mixed|\Phalcon\DiInterface $dependencyInjector
-     * @param array $options
+     * @param mixed|\Twig_Environment $environment
      */
-    public function __construct($view, $dependencyInjector, array $options = [])
+    public function __construct($view, $dependencyInjector, $environment = null, $options = [])
     {
         parent::__construct($view, $dependencyInjector);
 
-        $loader = new \Twig_Loader_Filesystem($this->getView()->getViewsDir());
-        $this->twig = new \Twig_Environment($loader, $options);
+        if ($environment === null) {
+            $loader = new \Twig_Loader_Filesystem($this->getView()->getViewsDir());
+            $this->_twig = new \Twig_Environment($loader, $options);
+        } else {
+            $this->_twig = $environment;
+        }
+        
     }
 
     /**
@@ -42,7 +47,7 @@ class Twig extends Engine implements EngineInterface
             $params = [];
         }
 
-        $content = $this->twig->render(str_replace($this->getView()->getViewsDir(), '', $path), $params);
+        $content = $this->_twig->render(str_replace($this->getView()->getViewsDir(), '', $path), $params);
         if ($mustClean) {
             $this->getView()->setContent($content);
 

--- a/src/Mvc/View/Engine/Twig.php
+++ b/src/Mvc/View/Engine/Twig.php
@@ -16,24 +16,26 @@ class Twig extends Engine implements EngineInterface
     /**
      * @var \Twig_Environment
      */
-    protected $_twig;
+    protected $_environment;
 
     /**
      * @param mixed|\Phalcon\Mvc\ViewBaseInterface $view
      * @param mixed|\Phalcon\DiInterface $dependencyInjector
-     * @param mixed|\Twig_Environment $environment
+     * @param array $options
      */
-    public function __construct($view, $dependencyInjector, $environment = null, $options = [])
+    public function __construct($view, $dependencyInjector, array $environmentoOptions = [])
     {
         parent::__construct($view, $dependencyInjector);
 
-        if ($environment === null) {
-            $loader = new \Twig_Loader_Filesystem($this->getView()->getViewsDir());
-            $this->_twig = new \Twig_Environment($loader, $options);
-        } else {
-            $this->_twig = $environment;
-        }
-        
+        $loader = new \Twig_Loader_Filesystem($this->getView()->getViewsDir());
+        $this->_environment = new \Twig_Environment($loader, $options);
+    }
+
+    /**
+     * @return \Twig_Environment
+     */
+    public function getEnvironment() {
+        return $this->_environment;
     }
 
     /**
@@ -47,7 +49,7 @@ class Twig extends Engine implements EngineInterface
             $params = [];
         }
 
-        $content = $this->_twig->render(str_replace($this->getView()->getViewsDir(), '', $path), $params);
+        $content = $this->_environment->render(str_replace($this->getView()->getViewsDir(), '', $path), $params);
         if ($mustClean) {
             $this->getView()->setContent($content);
 


### PR DESCRIPTION
Add the possibility to inject the Twig environment into the engine
instead of letting it handle its the instantiation.

This way is possible to add functions, filters and extensions to the 
environment before creating the engine and then returning it.